### PR TITLE
support parent indexing

### DIFF
--- a/lib/bulk-proxy-endpoint.js
+++ b/lib/bulk-proxy-endpoint.js
@@ -197,10 +197,17 @@ class BulkProxyEndpoint extends EventEmitter {
      * Queue a document to for bulk loading.
      * @param {string} id
      * @param {object} doc
+     * @param {string} [parent]
      */
-    put(id, doc) {
+    put(id, doc, parent) {
+        id = String(id);
+
         const {chunks} = this[$private];
-        const action = {index: {_id: id}};
+        const action = {index: {_id: String(id)}};
+
+        if (parent) action.index._parent = String(parent);
+
+        // build chunk string with insert action and document
         const chunk = stringify(action) + "\n" + stringify(doc) + "\n";
 
         if (chunks.has(id)) {

--- a/lib/bulk-proxy.js
+++ b/lib/bulk-proxy.js
@@ -203,12 +203,13 @@ class BulkProxy extends EventEmitter {
      * @param {string} index
      * @param {string} doctype
      * @param {string} id
-     * @param {object} data
+     * @param {object} doc
+     * @param {string} [parent]
      */
-    put(index, doctype, id, doc) {
+    put(index, doctype, id, doc, parent) {
         const endpoint = this.endpoint(index, doctype);
 
-        endpoint.put(id, doc);
+        endpoint.put(id, doc, parent);
 
         if (endpoint.pending > this.breakerDocuments
             || endpoint.size > this.breakerSize) {

--- a/lib/request-handler.js
+++ b/lib/request-handler.js
@@ -1,4 +1,5 @@
-const {URL} = require("url");
+const {parse: parseurl, URL} = require("url");
+const {parse: parsequery} = require("querystring");
 const {STATUS_CODES} = require("http");
 const stringWriter = require("./string-writer");
 const {assign} = Object;
@@ -14,7 +15,9 @@ function requestHandler(proxy) {
      * @param {ServerResponse} res
      */
     return (req, res) => {
-        const {method, url: path} = req;
+        const {method, url} = req;
+        const {pathname: path, query} = parseurl(url);
+        const {parent} = parsequery(query);
         const [_, index, type, id] = path.split("/");
         const body = stringWriter();
 
@@ -49,7 +52,7 @@ function requestHandler(proxy) {
             const reqopts = assign({}, url, {method});
 
             try {
-                proxy.put(index, type, id, JSON.parse(String(body)));
+                proxy.put(index, type, id, JSON.parse(String(body)), parent);
                 sendStatus(202, makeResponse(index, type, id));
             } catch (err) {
                 if (err instanceof SyntaxError) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zingle/esbulker",
-  "version": "0.0.1-beta2",
+  "version": "0.0.1-beta3",
   "description": "Elasticsearch bulking proxy",
   "main": "index.js",
   "bin": {

--- a/test/test-bulk-proxy.js
+++ b/test/test-bulk-proxy.js
@@ -104,9 +104,10 @@ describe("BulkProxy(string)", () => {
         const doc = {id};
 
         proxy.endpoint(index, doctype).put = (...args) => {
-            expect(args.length).to.be(2);
+            expect(args.length).to.be(3);
             expect(args[0]).to.be(id);
             expect(args[1]).to.be(doc);
+            expect(args[2]).to.be(undefined);
             done();
         };
 


### PR DESCRIPTION
fixes #23 

Was previously ignoring `?parent=...` query.  This change appropriately passes that on to the bulk insert action.